### PR TITLE
Downgrade to apache-beam==2.48.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords=["virtualenv", "dependencies"]
 authors=[{ name = "Nathan Zimmerman", email = "npzimmerman@gmail.com"}]
 license= { text = "MIT" }
 requires-python=">=3.7"
-dependencies = ["apache-beam==2.53.0", "pyspark==3.5.1", "psutil==5.9.8"]
+dependencies = ["apache-beam==2.48.0", "pyspark==3.5.1", "psutil==5.9.8"]
 dynamic = ["version", "readme"]
 
 [project.urls]


### PR DESCRIPTION
`apache-beam==2.53.0` has the p[ython3.8 requirement it seems](https://github.com/apache/beam/blob/v2.53.0/sdks/python/setup.py#L220). Do we think this would work well or should I just go back to getting a different python version running on CentOS?

https://github.com/apache/beam/blob/v2.53.0/sdks/python/setup.py#L220